### PR TITLE
Adding macOS support

### DIFF
--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -77,7 +77,7 @@ tasks {
         dependsOn("jvmFatJar")
 
         workingDir("$projectDir")
-        commandLine("java", "-XstartOnFirstThread", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-triangle",  "-version")
+        commandLine("java", "-XstartOnFirstThread", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-triangle", "-version")
     }
 
     register("runCubeExample", Exec::class) {

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -77,42 +77,42 @@ tasks {
         dependsOn("jvmFatJar")
 
         workingDir("$projectDir")
-        commandLine("java", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-triangle")
+        commandLine("java", "-XstartOnFirstThread", "-DRUST_BACKTRACE=1", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-triangle",  "-version")
     }
 
     register("runCubeExample", Exec::class) {
         dependsOn("jvmFatJar")
 
         workingDir("$projectDir")
-        commandLine("java", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-cube")
+        commandLine("java", "-XstartOnFirstThread", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-cube")
     }
 
     register("runTextureExample", Exec::class) {
         dependsOn("jvmFatJar")
 
         workingDir("$projectDir")
-        commandLine("java", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-texture")
+        commandLine("java", "-XstartOnFirstThread", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-texture")
     }
 
     register("runEarthExample", Exec::class) {
         dependsOn("jvmFatJar")
 
         workingDir("$projectDir")
-        commandLine("java", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-earth")
+        commandLine("java", "-XstartOnFirstThread", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-earth")
     }
 
     register("runComputeExample", Exec::class) {
         dependsOn("jvmFatJar")
 
         workingDir("$projectDir")
-        commandLine("java", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-compute")
+        commandLine("java", "-XstartOnFirstThread", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-compute")
     }
 
     register("runMsaaExample", Exec::class) {
         dependsOn("jvmFatJar")
 
         workingDir("$projectDir")
-        commandLine("java", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-msaa")
+        commandLine("java", "-XstartOnFirstThread", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-msaa")
     }
 
     register("runCompareExample", Exec::class) {
@@ -133,6 +133,6 @@ tasks {
         dependsOn("jvmFatJar")
 
         workingDir("$projectDir")
-        commandLine("java", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-boid")
+        commandLine("java", "-XstartOnFirstThread", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-boid")
     }
 }

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -55,6 +55,17 @@ kotlin {
     }
 }
 
+fun exampleArgs(arg: String): List<String> {
+    var startOnFirstThread: String? = null
+    if (System.getProperty("os.name").contains("Mac")) {
+        startOnFirstThread = "-XstartOnFirstThread"
+    }
+
+    return listOf("java", startOnFirstThread, null, "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", arg)
+        .filterNotNull()
+        .toList()
+}
+
 tasks {
     register("buildWebExample") {
         dependsOn("jsBrowserDistribution")
@@ -77,62 +88,62 @@ tasks {
         dependsOn("jvmFatJar")
 
         workingDir("$projectDir")
-        commandLine("java", "-XstartOnFirstThread", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-triangle", "-version")
+        commandLine(exampleArgs("-triangle"))
     }
 
     register("runCubeExample", Exec::class) {
         dependsOn("jvmFatJar")
 
         workingDir("$projectDir")
-        commandLine("java", "-XstartOnFirstThread", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-cube")
+        commandLine(exampleArgs("-cube"))
     }
 
     register("runTextureExample", Exec::class) {
         dependsOn("jvmFatJar")
 
         workingDir("$projectDir")
-        commandLine("java", "-XstartOnFirstThread", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-texture")
+        commandLine(exampleArgs("-texture"))
     }
 
     register("runEarthExample", Exec::class) {
         dependsOn("jvmFatJar")
 
         workingDir("$projectDir")
-        commandLine("java", "-XstartOnFirstThread", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-earth")
+        commandLine(exampleArgs("-earth"))
     }
 
     register("runComputeExample", Exec::class) {
         dependsOn("jvmFatJar")
 
         workingDir("$projectDir")
-        commandLine("java", "-XstartOnFirstThread", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-compute")
+        commandLine(exampleArgs("-compute"))
     }
 
     register("runMsaaExample", Exec::class) {
         dependsOn("jvmFatJar")
 
         workingDir("$projectDir")
-        commandLine("java", "-XstartOnFirstThread", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-msaa")
+        commandLine(exampleArgs("-msaa"))
     }
 
     register("runCompareExample", Exec::class) {
         dependsOn("jvmFatJar")
 
         workingDir("$projectDir")
-        commandLine("java", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-computeCompare")
+        commandLine(exampleArgs("-computeCompare"))
     }
 
     register("runWindowExample", Exec::class) {
         dependsOn("jvmFatJar")
 
         workingDir("$projectDir")
-        commandLine("java", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-window")
+        commandLine(exampleArgs("-window"))
     }
 
     register("runBoidExample", Exec::class) {
         dependsOn("jvmFatJar")
 
         workingDir("$projectDir")
-        commandLine("java", "-XstartOnFirstThread", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-boid")
+        commandLine(exampleArgs("-boid"))
     }
 }

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -77,7 +77,7 @@ tasks {
         dependsOn("jvmFatJar")
 
         workingDir("$projectDir")
-        commandLine("java", "-XstartOnFirstThread", "-DRUST_BACKTRACE=1", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-triangle",  "-version")
+        commandLine("java", "-XstartOnFirstThread", "-jar", "$buildDir/libs/examples-fat-${project.version}.jar", "-triangle",  "-version")
     }
 
     register("runCubeExample", Exec::class) {

--- a/examples/src/jvmMain/kotlin/DesktopExample.kt
+++ b/examples/src/jvmMain/kotlin/DesktopExample.kt
@@ -6,6 +6,10 @@ import kotlinx.coroutines.runBlocking
 import msaa.runMsaaTriangle
 
 fun main(args: Array<String>) {
+    // This is required for macOS else things will hang on anything texture related
+    // See https://github.com/LWJGL/lwjgl3/issues/68#issuecomment-113727632
+    System.setProperty("java.awt.headless", "true")
+
     println("Args: ${args.joinToString()}")
 
     val arg =

--- a/modules/kgpu/src/jvmMain/kotlin/io/github/kgpu/JvmWindow.kt
+++ b/modules/kgpu/src/jvmMain/kotlin/io/github/kgpu/JvmWindow.kt
@@ -38,7 +38,7 @@ actual class Window actual constructor() {
             } else if (Platform.isLinux) {
                 val display = GLFWNativeX11.glfwGetX11Display()
                 WgpuJava.wgpuNative.wgpu_create_surface_from_xlib(display, osHandle)
-            } else {
+            } else if (Platform.isMac) {
                 val objc_msgSend = ObjCRuntime.getLibrary().getFunctionAddress("objc_msgSend")
                 val CAMetalLayer = objc_getClass("CAMetalLayer")
                 val contentView = invokePPP(osHandle, sel_getUid("contentView"), objc_msgSend)
@@ -49,6 +49,10 @@ actual class Window actual constructor() {
                 //[ns_window.contentView setLayer:metal_layer];
                 invokePPPP(contentView, sel_getUid("setLayer:"), metal_layer, objc_msgSend);
                 WgpuJava.wgpuNative.wgpu_create_surface_from_metal_layer(metal_layer)
+            } else {
+                println(
+                    "[WARNING] Platform not tested. See " + "https://github.com/kgpu/kgpu/issues/1")
+                0
             }
 
         if (handle == MemoryUtil.NULL)
@@ -189,8 +193,11 @@ internal object GlfwHandler {
             Platform.isLinux -> {
                 GLFWNativeX11.glfwGetX11Window(handle)
             }
-            else -> {
+            Platform.isMac -> {
                 GLFWNativeCocoa.glfwGetCocoaWindow(handle)
+            }
+            else -> {
+                0
             }
         }
     }

--- a/modules/kgpu/src/jvmMain/kotlin/io/github/kgpu/JvmWindow.kt
+++ b/modules/kgpu/src/jvmMain/kotlin/io/github/kgpu/JvmWindow.kt
@@ -6,11 +6,11 @@ import io.github.kgpu.wgpuj.jni.WgpuSwapChainDescriptor
 import io.github.kgpu.wgpuj.util.Platform
 import java.nio.IntBuffer
 import org.lwjgl.glfw.*
+import org.lwjgl.system.JNI.*
 import org.lwjgl.system.MemoryStack
 import org.lwjgl.system.MemoryUtil
 import org.lwjgl.system.macosx.ObjCRuntime
 import org.lwjgl.system.macosx.ObjCRuntime.*
-import org.lwjgl.system.JNI.*
 
 actual class Window actual constructor() {
     private val handle: Long = GLFW.glfwCreateWindow(640, 480, "", MemoryUtil.NULL, MemoryUtil.NULL)
@@ -42,12 +42,12 @@ actual class Window actual constructor() {
                 val objc_msgSend = ObjCRuntime.getLibrary().getFunctionAddress("objc_msgSend")
                 val CAMetalLayer = objc_getClass("CAMetalLayer")
                 val contentView = invokePPP(osHandle, sel_getUid("contentView"), objc_msgSend)
-                //[ns_window.contentView setWantsLayer:YES];
-                invokePPV(contentView, sel_getUid("setWantsLayer:"), true, objc_msgSend);
-                //metal_layer = [CAMetalLayer layer];
+                // [ns_window.contentView setWantsLayer:YES];
+                invokePPV(contentView, sel_getUid("setWantsLayer:"), true, objc_msgSend)
+                // metal_layer = [CAMetalLayer layer];
                 val metal_layer = invokePPP(CAMetalLayer, sel_registerName("layer"), objc_msgSend)
-                //[ns_window.contentView setLayer:metal_layer];
-                invokePPPP(contentView, sel_getUid("setLayer:"), metal_layer, objc_msgSend);
+                // [ns_window.contentView setLayer:metal_layer];
+                invokePPPP(contentView, sel_getUid("setLayer:"), metal_layer, objc_msgSend)
                 WgpuJava.wgpuNative.wgpu_create_surface_from_metal_layer(metal_layer)
             } else {
                 println(

--- a/wgpuj/src/main/java/io/github/kgpu/wgpuj/jni/WgpuJNI.java
+++ b/wgpuj/src/main/java/io/github/kgpu/wgpuj/jni/WgpuJNI.java
@@ -188,6 +188,9 @@ public interface WgpuJNI {
     @u_int64_t
     long wgpu_create_surface_from_xlib(@u_int64_t long display, @u_int64_t long window);
 
+    @u_int64_t
+    long wgpu_create_surface_from_metal_layer(@u_int64_t long layer);
+
     void wgpu_buffer_destroy(@u_int64_t long buffer);
 
     void wgpu_texture_destroy(@u_int64_t long texture);


### PR DESCRIPTION
Aims to solve #1. 

So this gets most of the examples running on macOS. `./gradlew runEarthExample` and `./gradlew runTextureExample` hang without even a window getting displayed. I had a poke around and found that `resourcesVfs[path].readBitmap()` in ExampleUtils.kt is the culprit. Gut feeling is concurrency issues but I don't know.  

Disclaimer: don't know much about Kotlin or macOS native stuff.

This adds the jvm option `-XstartOnFirstThread` to the example programs. This is needed for things to run under macOS. See [this issue](https://github.com/LWJGL/lwjgl3/issues/538) for instance. I am guessing you may only want it set for running under macOS.

The main added code does this:

```
NSWindow *ns_window = glfwGetCocoaWindow(window);
[ns_window.contentView setWantsLayer:YES];
metal_layer = [CAMetalLayer layer];
[ns_window.contentView setLayer:metal_layer];
surface = wgpu_create_surface_from_metal_layer(metal_layer);
```

I got this snippet [here](https://gist.github.com/radgeRayden/548d101bd7b83e4366a413789866e90a).

I just have a macbook on me right now so I have not tested if things still work on other platforms.